### PR TITLE
remove ALLOWED_USERS permission system from all files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,11 +8,6 @@ OPENROUTER_API_KEY=sk-or-v1-your-key-here
 # Create a bot via @BotFather on Telegram
 TELEGRAM_BOT_TOKEN=123456789:ABCdefGHIjklMNOpqrSTUvwxYZ
 
-# Security: Allowed Telegram user IDs for transactions (comma-separated)
-# Find your ID by messaging @userinfobot on Telegram
-# Users NOT in this list can only use read-only tools (check balances, etc.)
-ALLOWED_USERS=123456789,987654321
-
 # Network: mainnet (real money) or testnet (test tokens)
 NETWORK=mainnet
 

--- a/README.md
+++ b/README.md
@@ -151,10 +151,6 @@ Set during setup (configurable in `data/workspace/memory/state.json`):
 | Balanced (default) | $10/day | $5 | Daily operations, routine DeFi |
 | Autonomous | $50/day | $25 | Active trading, high trust |
 
-### User Authorization
-
-Only Telegram users in `ALLOWED_USERS` can execute transactions (Tier 1-3). Everyone else can use read-only tools (Tier 0).
-
 ### Security Features
 
 - **Session-based wallet unlock** - Unlocked once per session, not per transaction
@@ -210,15 +206,10 @@ Edit `.env` to change settings:
 OPENROUTER_API_KEY=sk-or-v1-...
 TELEGRAM_BOT_TOKEN=123456:ABC...
 
-# Security: Users who can execute transactions (comma-separated Telegram user IDs)
-ALLOWED_USERS=123456789,987654321
-
 # Optional
 NETWORK=mainnet          # or testnet
 OPENCLAW_GATEWAY_PORT=18789
 ```
-
-**Finding your Telegram user ID**: Message [@userinfobot](https://t.me/userinfobot) on Telegram
 
 ## Wallet Setup
 

--- a/local-setup.sh
+++ b/local-setup.sh
@@ -295,28 +295,6 @@ Check daemon status:
 
 ---
 
-## USER PERMISSION SYSTEM
-
-**Two permission levels based on Telegram user ID:**
-
-1. **Allowed Users** (in ALLOWED_USERS env var) - Can execute ALL operations including transactions
-2. **Public Users** (everyone else) - Can ONLY use read-only (Tier 0) tools
-
-### Checking Permissions
-
-The allowed user IDs are stored in the environment variable `ALLOWED_USERS` (comma-separated).
-
-**BEFORE ANY WRITE OPERATION, you MUST:**
-1. Identify the current Telegram user's ID from the conversation context
-2. Check if their ID is in the ALLOWED_USERS list
-3. If NOT allowed: Politely decline and explain only read-only tools are available to them
-4. If allowed: Proceed using the autonomous operation model below
-
-**Example decline message:**
-> "I can help you check balances, look up BNS names, and view DeFi info, but transaction operations are restricted to authorized users only."
-
----
-
 ## AUTONOMOUS SECURITY MODEL
 
 This agent operates autonomously within configured limits. Security comes from **spending caps and operation tiers**, not from asking permission on every transaction.
@@ -382,7 +360,7 @@ Safe read-only operations. Available to ALL users (including public).
 | sBTC peg info | `aibtc.sbtc_get_peg_info` |
 | Read-only contract call | `aibtc.call_read_only_function` |
 
-#### Tier 1: Auto-Approved Within Limits (Allowed Users Only)
+#### Tier 1: Auto-Approved Within Limits
 
 The agent executes these **autonomously** as long as:
 - The per-transaction amount is within the per-tx limit (default: $5 equivalent)
@@ -408,7 +386,7 @@ The agent executes these **autonomously** as long as:
 3. After execution, update `state.json` counters: increment `todaySpent`, `totalTransactions`, `transactionsToday`, `lifetimeAutoTransactions`
 4. Log the transaction in journal.md
 
-#### Tier 2: Requires Human Confirmation (Allowed Users Only)
+#### Tier 2: Requires Human Confirmation
 
 The agent explains what it wants to do and **asks the human to confirm** (yes/no). No password is needed -- the wallet is already unlocked for the session. Use this tier when:
 - A Tier 1 operation exceeds the per-tx or daily limit
@@ -486,7 +464,7 @@ At the beginning of each operating session:
 ### During Session
 
 - Execute Tier 0 operations freely for any user
-- Execute Tier 1 operations autonomously for allowed users (check limits)
+- Execute Tier 1 operations autonomously (check limits)
 - Escalate to Tier 2 when limits are exceeded
 - Always escalate to Tier 3 for dangerous operations
 - Track spending in state.json after every transaction
@@ -575,9 +553,7 @@ These operations are safe, don't require wallet unlock, and can be used by any u
 
 ---
 
-## Write Operations (Tier 1/2 - ALLOWED USERS ONLY)
-
-**RESTRICTED: Only users in ALLOWED_USERS can execute these operations.**
+## Write Operations (Tier 1/2)
 
 Tier 1 operations execute autonomously within limits. Tier 2 operations require human confirmation (but not password).
 

--- a/setup.sh
+++ b/setup.sh
@@ -98,24 +98,9 @@ if [ "$SKIP_CONFIG" != "true" ]; then
         NETWORK="mainnet"
     fi
 
-    # Allowed users for transactions
-    echo ""
-    echo -e "${YELLOW}Step 4: Allowed Users (Transaction Security)${NC}"
-    echo "Only these Telegram users can execute transactions."
-    echo "Others can still use read-only tools (check balances, etc.)"
-    echo ""
-    echo "To find your Telegram ID: Message @userinfobot on Telegram"
-    echo ""
-    read -p "Enter allowed Telegram user IDs (comma-separated): " ALLOWED_USERS < /dev/tty
-
-    if [ -z "$ALLOWED_USERS" ]; then
-        echo -e "${RED}Error: At least one allowed user ID is required for security.${NC}"
-        exit 1
-    fi
-
     # Wallet password
     echo ""
-    echo -e "${YELLOW}Step 5: Agent Wallet Password${NC}"
+    echo -e "${YELLOW}Step 4: Agent Wallet Password${NC}"
     echo "Your agent will have its own Bitcoin wallet."
     echo "This password is stored securely so the agent can self-unlock."
     echo ""
@@ -134,7 +119,7 @@ if [ "$SKIP_CONFIG" != "true" ]; then
 
     # Autonomy level
     echo ""
-    echo -e "${YELLOW}Step 6: Autonomy Level${NC}"
+    echo -e "${YELLOW}Step 5: Autonomy Level${NC}"
     echo "How independently should your agent operate?"
     echo ""
     echo "  1) Conservative  - Agent asks before most transactions (\$1/day limit)"
@@ -199,10 +184,6 @@ TELEGRAM_BOT_TOKEN=${TELEGRAM_TOKEN}
 
 # Network: mainnet or testnet
 NETWORK=${NETWORK}
-
-# Allowed Telegram user IDs for transactions (comma-separated)
-# Others can use read-only tools but cannot execute transactions
-ALLOWED_USERS=${ALLOWED_USERS}
 
 # Gateway token (auto-generated)
 OPENCLAW_GATEWAY_TOKEN=${GATEWAY_TOKEN}
@@ -377,28 +358,6 @@ Check daemon status:
 
 ---
 
-## USER PERMISSION SYSTEM
-
-**Two permission levels based on Telegram user ID:**
-
-1. **Allowed Users** (in ALLOWED_USERS env var) - Can execute ALL operations including transactions
-2. **Public Users** (everyone else) - Can ONLY use read-only (Tier 0) tools
-
-### Checking Permissions
-
-The allowed user IDs are stored in the environment variable `ALLOWED_USERS` (comma-separated).
-
-**BEFORE ANY WRITE OPERATION, you MUST:**
-1. Identify the current Telegram user's ID from the conversation context
-2. Check if their ID is in the ALLOWED_USERS list
-3. If NOT allowed: Politely decline and explain only read-only tools are available to them
-4. If allowed: Proceed using the autonomous operation model below
-
-**Example decline message:**
-> "I can help you check balances, look up BNS names, and view DeFi info, but transaction operations are restricted to authorized users only."
-
----
-
 ## AUTONOMOUS SECURITY MODEL
 
 This agent operates autonomously within configured limits. Security comes from **spending caps and operation tiers**, not from asking permission on every transaction.
@@ -464,7 +423,7 @@ Safe read-only operations. Available to ALL users (including public).
 | sBTC peg info | `aibtc.sbtc_get_peg_info` |
 | Read-only contract call | `aibtc.call_read_only_function` |
 
-#### Tier 1: Auto-Approved Within Limits (Allowed Users Only)
+#### Tier 1: Auto-Approved Within Limits
 
 The agent executes these **autonomously** as long as:
 - The per-transaction amount is within the per-tx limit (default: $5 equivalent)
@@ -490,7 +449,7 @@ The agent executes these **autonomously** as long as:
 3. After execution, update `state.json` counters: increment `todaySpent`, `totalTransactions`, `transactionsToday`, `lifetimeAutoTransactions`
 4. Log the transaction in journal.md
 
-#### Tier 2: Requires Human Confirmation (Allowed Users Only)
+#### Tier 2: Requires Human Confirmation
 
 The agent explains what it wants to do and **asks the human to confirm** (yes/no). No password is needed -- the wallet is already unlocked for the session. Use this tier when:
 - A Tier 1 operation exceeds the per-tx or daily limit
@@ -568,7 +527,7 @@ At the beginning of each operating session:
 ### During Session
 
 - Execute Tier 0 operations freely for any user
-- Execute Tier 1 operations autonomously for allowed users (check limits)
+- Execute Tier 1 operations autonomously (check limits)
 - Escalate to Tier 2 when limits are exceeded
 - Always escalate to Tier 3 for dangerous operations
 - Track spending in state.json after every transaction
@@ -657,9 +616,7 @@ These operations are safe, don't require wallet unlock, and can be used by any u
 
 ---
 
-## Write Operations (Tier 1/2 - ALLOWED USERS ONLY)
-
-**RESTRICTED: Only users in ALLOWED_USERS can execute these operations.**
+## Write Operations (Tier 1/2)
 
 Tier 1 operations execute autonomously within limits. Tier 2 operations require human confirmation (but not password).
 

--- a/skills/aibtc/SKILL.md
+++ b/skills/aibtc/SKILL.md
@@ -28,28 +28,6 @@ Check daemon status:
 
 ---
 
-## USER PERMISSION SYSTEM
-
-**Two permission levels based on Telegram user ID:**
-
-1. **Allowed Users** (in ALLOWED_USERS env var) - Can execute ALL operations including transactions
-2. **Public Users** (everyone else) - Can ONLY use read-only (Tier 0) tools
-
-### Checking Permissions
-
-The allowed user IDs are stored in the environment variable `ALLOWED_USERS` (comma-separated).
-
-**BEFORE ANY WRITE OPERATION, you MUST:**
-1. Identify the current Telegram user's ID from the conversation context
-2. Check if their ID is in the ALLOWED_USERS list
-3. If NOT allowed: Politely decline and explain only read-only tools are available to them
-4. If allowed: Proceed using the autonomous operation model below
-
-**Example decline message:**
-> "I can help you check balances, look up BNS names, and view DeFi info, but transaction operations are restricted to authorized users only."
-
----
-
 ## AUTONOMOUS SECURITY MODEL
 
 This agent operates autonomously within configured limits. Security comes from **spending caps and operation tiers**, not from asking permission on every transaction.
@@ -115,7 +93,7 @@ Safe read-only operations. Available to ALL users (including public).
 | sBTC peg info | `aibtc.sbtc_get_peg_info` |
 | Read-only contract call | `aibtc.call_read_only_function` |
 
-#### Tier 1: Auto-Approved Within Limits (Allowed Users Only)
+#### Tier 1: Auto-Approved Within Limits
 
 The agent executes these **autonomously** as long as:
 - The per-transaction amount is within the per-tx limit (default: $5 equivalent)
@@ -141,7 +119,7 @@ The agent executes these **autonomously** as long as:
 3. After execution, update `state.json` counters: increment `todaySpent`, `totalTransactions`, `transactionsToday`, `lifetimeAutoTransactions`
 4. Log the transaction in journal.md
 
-#### Tier 2: Requires Human Confirmation (Allowed Users Only)
+#### Tier 2: Requires Human Confirmation
 
 The agent explains what it wants to do and **asks the human to confirm** (yes/no). No password is needed -- the wallet is already unlocked for the session. Use this tier when:
 - A Tier 1 operation exceeds the per-tx or daily limit
@@ -219,7 +197,7 @@ At the beginning of each operating session:
 ### During Session
 
 - Execute Tier 0 operations freely for any user
-- Execute Tier 1 operations autonomously for allowed users (check limits)
+- Execute Tier 1 operations autonomously (check limits)
 - Escalate to Tier 2 when limits are exceeded
 - Always escalate to Tier 3 for dangerous operations
 - Track spending in state.json after every transaction
@@ -308,9 +286,7 @@ These operations are safe, don't require wallet unlock, and can be used by any u
 
 ---
 
-## Write Operations (Tier 1/2 - ALLOWED USERS ONLY)
-
-**RESTRICTED: Only users in ALLOWED_USERS can execute these operations.**
+## Write Operations (Tier 1/2)
 
 Tier 1 operations execute autonomously within limits. Tier 2 operations require human confirmation (but not password).
 

--- a/update-skill.sh
+++ b/update-skill.sh
@@ -64,28 +64,6 @@ Check daemon status:
 
 ---
 
-## USER PERMISSION SYSTEM
-
-**Two permission levels based on Telegram user ID:**
-
-1. **Allowed Users** (in ALLOWED_USERS env var) - Can execute ALL operations including transactions
-2. **Public Users** (everyone else) - Can ONLY use read-only (Tier 0) tools
-
-### Checking Permissions
-
-The allowed user IDs are stored in the environment variable `ALLOWED_USERS` (comma-separated).
-
-**BEFORE ANY WRITE OPERATION, you MUST:**
-1. Identify the current Telegram user's ID from the conversation context
-2. Check if their ID is in the ALLOWED_USERS list
-3. If NOT allowed: Politely decline and explain only read-only tools are available to them
-4. If allowed: Proceed using the autonomous operation model below
-
-**Example decline message:**
-> "I can help you check balances, look up BNS names, and view DeFi info, but transaction operations are restricted to authorized users only."
-
----
-
 ## AUTONOMOUS SECURITY MODEL
 
 This agent operates autonomously within configured limits. Security comes from **spending caps and operation tiers**, not from asking permission on every transaction.
@@ -151,7 +129,7 @@ Safe read-only operations. Available to ALL users (including public).
 | sBTC peg info | `aibtc.sbtc_get_peg_info` |
 | Read-only contract call | `aibtc.call_read_only_function` |
 
-#### Tier 1: Auto-Approved Within Limits (Allowed Users Only)
+#### Tier 1: Auto-Approved Within Limits
 
 The agent executes these **autonomously** as long as:
 - The per-transaction amount is within the per-tx limit (default: $5 equivalent)
@@ -177,7 +155,7 @@ The agent executes these **autonomously** as long as:
 3. After execution, update `state.json` counters: increment `todaySpent`, `totalTransactions`, `transactionsToday`, `lifetimeAutoTransactions`
 4. Log the transaction in journal.md
 
-#### Tier 2: Requires Human Confirmation (Allowed Users Only)
+#### Tier 2: Requires Human Confirmation
 
 The agent explains what it wants to do and **asks the human to confirm** (yes/no). No password is needed -- the wallet is already unlocked for the session. Use this tier when:
 - A Tier 1 operation exceeds the per-tx or daily limit
@@ -255,7 +233,7 @@ At the beginning of each operating session:
 ### During Session
 
 - Execute Tier 0 operations freely for any user
-- Execute Tier 1 operations autonomously for allowed users (check limits)
+- Execute Tier 1 operations autonomously (check limits)
 - Escalate to Tier 2 when limits are exceeded
 - Always escalate to Tier 3 for dangerous operations
 - Track spending in state.json after every transaction
@@ -344,9 +322,7 @@ These operations are safe, don't require wallet unlock, and can be used by any u
 
 ---
 
-## Write Operations (Tier 1/2 - ALLOWED USERS ONLY)
-
-**RESTRICTED: Only users in ALLOWED_USERS can execute these operations.**
+## Write Operations (Tier 1/2)
 
 Tier 1 operations execute autonomously within limits. Tier 2 operations require human confirmation (but not password).
 

--- a/vps-setup.sh
+++ b/vps-setup.sh
@@ -350,28 +350,6 @@ Check daemon status:
 
 ---
 
-## USER PERMISSION SYSTEM
-
-**Two permission levels based on Telegram user ID:**
-
-1. **Allowed Users** (in ALLOWED_USERS env var) - Can execute ALL operations including transactions
-2. **Public Users** (everyone else) - Can ONLY use read-only (Tier 0) tools
-
-### Checking Permissions
-
-The allowed user IDs are stored in the environment variable `ALLOWED_USERS` (comma-separated).
-
-**BEFORE ANY WRITE OPERATION, you MUST:**
-1. Identify the current Telegram user's ID from the conversation context
-2. Check if their ID is in the ALLOWED_USERS list
-3. If NOT allowed: Politely decline and explain only read-only tools are available to them
-4. If allowed: Proceed using the autonomous operation model below
-
-**Example decline message:**
-> "I can help you check balances, look up BNS names, and view DeFi info, but transaction operations are restricted to authorized users only."
-
----
-
 ## AUTONOMOUS SECURITY MODEL
 
 This agent operates autonomously within configured limits. Security comes from **spending caps and operation tiers**, not from asking permission on every transaction.
@@ -437,7 +415,7 @@ Safe read-only operations. Available to ALL users (including public).
 | sBTC peg info | `aibtc.sbtc_get_peg_info` |
 | Read-only contract call | `aibtc.call_read_only_function` |
 
-#### Tier 1: Auto-Approved Within Limits (Allowed Users Only)
+#### Tier 1: Auto-Approved Within Limits
 
 The agent executes these **autonomously** as long as:
 - The per-transaction amount is within the per-tx limit (default: $5 equivalent)
@@ -463,7 +441,7 @@ The agent executes these **autonomously** as long as:
 3. After execution, update `state.json` counters: increment `todaySpent`, `totalTransactions`, `transactionsToday`, `lifetimeAutoTransactions`
 4. Log the transaction in journal.md
 
-#### Tier 2: Requires Human Confirmation (Allowed Users Only)
+#### Tier 2: Requires Human Confirmation
 
 The agent explains what it wants to do and **asks the human to confirm** (yes/no). No password is needed -- the wallet is already unlocked for the session. Use this tier when:
 - A Tier 1 operation exceeds the per-tx or daily limit
@@ -541,7 +519,7 @@ At the beginning of each operating session:
 ### During Session
 
 - Execute Tier 0 operations freely for any user
-- Execute Tier 1 operations autonomously for allowed users (check limits)
+- Execute Tier 1 operations autonomously (check limits)
 - Escalate to Tier 2 when limits are exceeded
 - Always escalate to Tier 3 for dangerous operations
 - Track spending in state.json after every transaction
@@ -630,9 +608,7 @@ These operations are safe, don't require wallet unlock, and can be used by any u
 
 ---
 
-## Write Operations (Tier 1/2 - ALLOWED USERS ONLY)
-
-**RESTRICTED: Only users in ALLOWED_USERS can execute these operations.**
+## Write Operations (Tier 1/2)
 
 Tier 1 operations execute autonomously within limits. Tier 2 operations require human confirmation (but not password).
 


### PR DESCRIPTION
The agent operates autonomously within spending limits — the Telegram user ID-based permission system is no longer needed.

Removes from setup.sh, local-setup.sh, vps-setup.sh, update-skill.sh, skills/aibtc/SKILL.md, .env.example, and README.md:
- Step 4 prompt and ALLOWED_USERS env var
- USER PERMISSION SYSTEM section from SKILL.md heredocs
- (Allowed Users Only) qualifiers from tier headers
- RESTRICTED lines from Write Operations sections