### PR TITLE
fix: persist wallet and credentials across Docker rebuilds

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+set -e
+
+# Persist wallet data (~/.aibtc) and moltbook credentials (~/.config/moltbook)
+# across Docker rebuilds by symlinking them into the mounted volume at ~/.openclaw/
+#
+# The docker-compose volume mount (./data:/home/node/.openclaw) ensures everything
+# under ~/.openclaw/ survives rebuilds. This script creates symlinks so that tools
+# writing to ~/.aibtc or ~/.config/moltbook transparently use the volume.
+
+# Ensure persistent directories exist inside the volume
+mkdir -p /home/node/.openclaw/aibtc-data
+mkdir -p /home/node/.openclaw/moltbook-data
+
+# --- Wallet store (~/.aibtc → volume) ---
+if [ -L /home/node/.aibtc ]; then
+    : # Already a symlink, nothing to do
+elif [ -d /home/node/.aibtc ]; then
+    # Migrate existing data into the volume, then replace with symlink
+    cp -a /home/node/.aibtc/. /home/node/.openclaw/aibtc-data/ 2>/dev/null || true
+    rm -rf /home/node/.aibtc
+    ln -s /home/node/.openclaw/aibtc-data /home/node/.aibtc
+else
+    ln -s /home/node/.openclaw/aibtc-data /home/node/.aibtc
+fi
+
+# --- Moltbook credentials (~/.config/moltbook → volume) ---
+mkdir -p /home/node/.config
+if [ -L /home/node/.config/moltbook ]; then
+    : # Already a symlink
+elif [ -d /home/node/.config/moltbook ]; then
+    cp -a /home/node/.config/moltbook/. /home/node/.openclaw/moltbook-data/ 2>/dev/null || true
+    rm -rf /home/node/.config/moltbook
+    ln -s /home/node/.openclaw/moltbook-data /home/node/.config/moltbook
+else
+    ln -s /home/node/.openclaw/moltbook-data /home/node/.config/moltbook
+fi
+
+# Hand off to the original CMD
+exec "$@"


### PR DESCRIPTION
## Problem

Wallet data at `~/.aibtc/` and Moltbook credentials at `~/.config/moltbook/` are stored outside the Docker volume mount (`~/.openclaw/`). Every `docker compose build` wipes both — the agent loses its wallet (and the mnemonic was only shown once during first boot), plus its Moltbook identity.

Additionally, the Dockerfile pins old versions of `@aibtc/mcp-server@1.14.2` and `mcporter@0.7.3`, preventing agents from getting updates.

Fixes #17

## Solution

### 1. `entrypoint.sh` (new file)
Runs before the gateway starts. Creates symlinks so tools writing to `~/.aibtc` and `~/.config/moltbook` transparently use persistent directories inside the volume:

- `~/.aibtc` → `~/.openclaw/aibtc-data/`
- `~/.config/moltbook` → `~/.openclaw/moltbook-data/`

If existing (non-symlinked) data is found, it's migrated into the volume automatically.

### 2. Dockerfile changes
- `@aibtc/mcp-server@latest` and `mcporter@latest` instead of pinned versions
- `chown` on installed packages so the agent can self-update via npm
- `ENTRYPOINT` set to `entrypoint.sh` with the original CMD preserved

### 3. `local-setup.sh` changes
The inline Dockerfile and new entrypoint.sh creation match the repo Dockerfile exactly.

## No changes needed to `docker-compose.yml`
The existing volume mount `./data:/home/node/.openclaw` already covers everything — we just needed the data stored *inside* that mount point.

---
Signed-by: cocoa007.btc (BTC: bc1qv8dt3v9kx3l7r9mnz2gj9r9n9k63frn6w6zmrt)
Signature: JzXq4FoXkaAA6zWR94cOwUtAUA2K7vqsLYFxFpYNkw/yZ5ddz/Mpux+WRqRz+ni/q3YlFO3ZtWjtMAYlPWlVRd8=