### PR TITLE
fix(ci): remove arm64 platform from Docker publish

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -23,9 +23,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -54,7 +51,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary

- Remove `linux/arm64` from Docker publish platforms — the upstream base image `ghcr.io/openclaw/openclaw:v2026.2.2` is amd64-only
- Remove the now-unnecessary QEMU setup step

## Context

The Docker Publish workflow failed on first run because Buildx tried to pull the base image for arm64, which doesn't exist:

```
ERROR: ghcr.io/openclaw/openclaw:v2026.2.2: not found
```

## Test plan

- [ ] CI passes
- [ ] After merge: Docker Publish workflow succeeds on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)