### PR TITLE
fix(docker): correct base image tag, restore multi-platform build

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -51,7 +54,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # OpenClaw + aibtc Docker Image
 # Based on official OpenClaw image with aibtc-mcp-server pre-installed
 
-FROM ghcr.io/openclaw/openclaw:v2026.2.2
+FROM ghcr.io/openclaw/openclaw:2026.2.2
 
 USER root
 


### PR DESCRIPTION
## Summary

- Fix Dockerfile `FROM` tag: `v2026.2.2` → `2026.2.2` (upstream uses calver without `v` prefix)
- Restore `linux/arm64` platform and QEMU step (upstream image publishes both amd64 and arm64 variants)

## Root cause

The upstream `ghcr.io/openclaw/openclaw` image uses calver tags like `2026.2.2`, not `v2026.2.2`. The `v` prefix caused "not found" on the GHA runner. Verified available tags via ghcr.io API.

## Test plan

- [ ] CI passes
- [ ] After merge: Docker Publish workflow succeeds and pushes multi-platform image to ghcr.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)